### PR TITLE
chore(workspace): remove setup-node cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,12 +24,11 @@ jobs:
     steps:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
 
-      - run: corepack enable pnpm
-
       - uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
         with:
           node-version-file: '.nvmrc'
-          cache: pnpm
+
+      - run: corepack enable pnpm
 
       - run: pnpm install --frozen-lockfile
 
@@ -41,12 +40,11 @@ jobs:
     steps:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
 
-      - run: corepack enable pnpm
-
       - uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
         with:
           node-version-file: '.nvmrc'
-          cache: pnpm
+
+      - run: corepack enable pnpm
 
       - run: pnpm install --frozen-lockfile
 
@@ -58,12 +56,11 @@ jobs:
     steps:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
 
-      - run: corepack enable pnpm
-
       - uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
         with:
           node-version-file: '.nvmrc'
-          cache: pnpm
+
+      - run: corepack enable pnpm
 
       - run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,12 +32,11 @@ jobs:
     steps:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
 
-      - run: corepack enable pnpm
-
       - uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
         with:
           node-version-file: '.nvmrc'
-          cache: pnpm
+
+      - run: corepack enable pnpm
 
       - run: pnpm install --frozen-lockfile
 


### PR DESCRIPTION
#### What this PR does / why we need it:

As per title, let pnpm do the download and resolution. I do not think we should pre-optimize for this.
