### PR TITLE
fix(examples): no cache for buildTransaction

### DIFF
--- a/examples/levain-graphql-examples/src/api/api-cosigning-erc20.ts
+++ b/examples/levain-graphql-examples/src/api/api-cosigning-erc20.ts
@@ -5,7 +5,7 @@ import dotenv from 'dotenv';
 import { decrypt, prefixHex, stripHexPrefix } from '../utils/crypto';
 import {
   approveTransactionRequest,
-  buildErc20Transaction,
+  buildTransaction,
   createTransactionDigests,
   createTransactionRequest,
   executeTransaction,
@@ -45,7 +45,7 @@ router.get('/process-withdrawal-erc20', async (req, res) => {
     }
 
     // Build ERC-20 transfer transaction to get the tx data
-    const erc20Transaction = await buildErc20Transaction(walletId, {
+    const erc20Transaction = await buildTransaction(walletId, {
       to: withdrawalAddress as string,
       asset: tokenContractCaip19,
       amount: 0.00001, // Decimals are taken care of by Levain, only input the formatted amount e.g. 10.5 UNI, 20 USDT etc.

--- a/examples/levain-graphql-examples/src/api/api-cosigning-trc20.ts
+++ b/examples/levain-graphql-examples/src/api/api-cosigning-trc20.ts
@@ -5,7 +5,7 @@ import dotenv from 'dotenv';
 import { decrypt, prefixHex, stripHexPrefix } from '../utils/crypto';
 import {
   approveTransactionRequest,
-  buildErc20Transaction,
+  buildTransaction,
   createTransactionDigests,
   createTransactionRequest,
   executeTransaction,
@@ -45,8 +45,8 @@ router.get('/process-withdrawal-trc20', async (req, res) => {
       throw new Error('You must specify an address to send to');
     }
 
-    // Build ERC-20 transfer transaction to get the tx data
-    const erc20Transaction = await buildErc20Transaction(walletId, {
+    // Build TRC-20 transfer transaction to get the tx data
+    const erc20Transaction = await buildTransaction(walletId, {
       to: withdrawalAddress as string,
       asset: tokenContractCaip19,
       amount: 1, // Decimals are taken care of by Levain, only input the formatted amount e.g. 10.5 UNI, 20 USDT etc.

--- a/examples/levain-graphql-examples/src/utils/mutations.ts
+++ b/examples/levain-graphql-examples/src/utils/mutations.ts
@@ -21,10 +21,10 @@ export interface NewSimpleMultiSigTransactionRequestData {
   gasLimit: string;
 }
 
-// Using Levain to build an ERC-20 transaction
-export async function buildErc20Transaction(walletId: string, input: any) {
-  const BUILD_ERC20_TRANSACTION = gql`
-    query BuildERC20Transaction($walletId: ID!, $input: BuildTransactionInput!) {
+// Using Levain to build a token transfer transaction
+export async function buildTransaction(walletId: string, input: any) {
+  const BUILD_TRANSACTION = gql`
+    query BuildTransaction($walletId: ID!, $input: BuildTransactionInput!) {
       wallet(walletId: $walletId) {
         buildTransaction(input: $input)
       }
@@ -32,8 +32,9 @@ export async function buildErc20Transaction(walletId: string, input: any) {
   `;
 
   const response = await client.query({
-    query: BUILD_ERC20_TRANSACTION,
+    query: BUILD_TRANSACTION,
     variables: { walletId, input },
+    fetchPolicy: 'no-cache',
   });
 
   return response.data.wallet.buildTransaction;


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

- `no-cache` for buildTransaction due to apollo defaulting to client-side caching
- rename buildTransaction to cater to Tron

#### Which issue(s) will this PR fix?:

<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

#### Additional comments?:
