### PR TITLE
chore(sdk-example): use type-safe config

### DIFF
--- a/examples/levain-sdk-examples/src/api/001-create-wallet.ts
+++ b/examples/levain-sdk-examples/src/api/001-create-wallet.ts
@@ -1,7 +1,7 @@
 import express from 'express';
 import { levainGraph } from './client';
 import { WalletType } from '@levain/wallet-sdk';
-import { requireValue } from './utils';
+import { config } from './config';
 
 const router = express.Router();
 
@@ -9,7 +9,7 @@ const router = express.Router();
 router.get('/create-wallet', async (req, res) => {
   try {
     const { keys, wallet } = await levainGraph.createKeysAndWallet({
-      orgId: requireValue(process.env.LEVAIN_ORG_ID, '`LEVAIN_ORG_ID` env var has not been set'),
+      orgId: config.LEVAIN_ORG_ID,
       type: WalletType.EvmContractSimpleMultiSig,
       name: 'Sepolia Test Wallet',
       network: 'caip2:eip155:11155111',

--- a/examples/levain-sdk-examples/src/api/002-api-cosigning.ts
+++ b/examples/levain-sdk-examples/src/api/002-api-cosigning.ts
@@ -1,6 +1,6 @@
 import express from 'express';
 import { levainGraph } from './client';
-import { requireValue } from './utils';
+import { config } from './config';
 
 const router = express.Router();
 
@@ -20,14 +20,8 @@ router.get('/process-withdrawal', async (req, res) => {
 
     const withdrawalAddress = req.query.address;
 
-    const walletId = requireValue(
-      process.env.LEVAIN_OPS_WITHDRAWAL_HOT_WALLET_ID,
-      '`LEVAIN_OPS_WITHDRAWAL_HOT_WALLET_ID` env var has not been set',
-    );
-    const walletPassword = requireValue(
-      process.env.LEVAIN_USER_SIGNING_KEY_PASSWORD,
-      '`LEVAIN_USER_SIGNING_KEY_PASSWORD` env var has not been set',
-    );
+    const walletId = config.LEVAIN_OPS_WITHDRAWAL_HOT_WALLET_ID;
+    const walletPassword = config.LEVAIN_USER_SIGNING_KEY_PASSWORD;
 
     // Create Transaction
     const txRequest = await levainGraph.sendAsset({

--- a/examples/levain-sdk-examples/src/api/003-api-cosigning-custom-tx.ts
+++ b/examples/levain-sdk-examples/src/api/003-api-cosigning-custom-tx.ts
@@ -1,6 +1,7 @@
 import express from 'express';
 import { levainGraph } from './client';
 import { requireValue } from './utils';
+import { config } from './config';
 
 const router = express.Router();
 
@@ -22,14 +23,8 @@ router.get('/process-tx', async (req, res) => {
     const json = await response.json();
     console.log(json);
 
-    const walletId = requireValue(
-      process.env.LEVAIN_OPS_WITHDRAWAL_HOT_WALLET_ID,
-      '`LEVAIN_OPS_WITHDRAWAL_HOT_WALLET_ID` env var has not been set',
-    );
-    const walletPassword = requireValue(
-      process.env.LEVAIN_USER_SIGNING_KEY_PASSWORD,
-      '`LEVAIN_USER_SIGNING_KEY_PASSWORD` env var has not been set',
-    );
+    const walletId = config.LEVAIN_OPS_WITHDRAWAL_HOT_WALLET_ID;
+    const walletPassword = config.LEVAIN_USER_SIGNING_KEY_PASSWORD;
 
     // Create tx request via Levain from Ops Withdrawal Hot Wallet to the user's wallet
     const createTxRequest = await levainGraph.createTransactionRequest({

--- a/examples/levain-sdk-examples/src/api/client.ts
+++ b/examples/levain-sdk-examples/src/api/client.ts
@@ -1,6 +1,7 @@
 import { LevainGraphClient } from '@levain/wallet-sdk';
+import { config } from './config';
 
 export const levainGraph = new LevainGraphClient({
-  accessToken: process.env.LEVAIN_API_ACCESS_TOKEN,
-  baseUrl: process.env.LEVAIN_API_URL,
+  accessToken: config.LEVAIN_API_ACCESS_TOKEN,
+  baseUrl: config.LEVAIN_API_URL,
 });

--- a/examples/levain-sdk-examples/src/api/config.ts
+++ b/examples/levain-sdk-examples/src/api/config.ts
@@ -1,0 +1,21 @@
+import dotenv from 'dotenv';
+import { join } from 'node:path';
+import { requireValue } from './utils';
+
+dotenv.config({
+  path: join(__dirname, '..', '..', '.env.example'),
+});
+
+export const config = {
+  LEVAIN_API_ACCESS_TOKEN: requireValue(process.env.LEVAIN_API_ACCESS_TOKEN, 'LEVAIN_API_ACCESS_TOKEN was not set.'),
+  LEVAIN_API_URL: requireValue(process.env.LEVAIN_API_URL, 'LEVAIN_API_URL was not set.'),
+  LEVAIN_ORG_ID: requireValue(process.env.LEVAIN_ORG_ID, 'LEVAIN_ORG_ID was not set.'),
+  LEVAIN_OPS_WITHDRAWAL_HOT_WALLET_ID: requireValue(
+    process.env.LEVAIN_OPS_WITHDRAWAL_HOT_WALLET_ID,
+    'LEVAIN_OPS_WITHDRAWAL_HOT_WALLET_ID was not set.',
+  ),
+  LEVAIN_USER_SIGNING_KEY_PASSWORD: requireValue(
+    process.env.LEVAIN_USER_SIGNING_KEY_PASSWORD,
+    'LEVAIN_USER_SIGNING_KEY_PASSWORD was not set.',
+  ),
+} as const;

--- a/examples/levain-sdk-examples/src/app.ts
+++ b/examples/levain-sdk-examples/src/app.ts
@@ -5,10 +5,14 @@ import txWith0xRoute from './api/003-api-cosigning-custom-tx';
 import depositAddressRoute from './api/004-generate-deposit-addresses';
 
 import { config } from 'dotenv';
+import { join } from 'node:path';
 
-config();
+config({
+  path: join(__dirname, '..', '.env.example'),
+});
+
 const app = express();
-const port = 3000;
+const port = 8000;
 
 app.get('/', async (req, res) => {
   try {


### PR DESCRIPTION
#### What this PR does / why we need it:
- As per title